### PR TITLE
更新test對話提示以包含歷史對話，並在對話管理器中隨機選擇回應進行儲存。調整test代碼以顯示最近的對話歷史，並清理對話歷史記錄。

### DIFF
--- a/prompts/dialogue_prompts.yaml
+++ b/prompts/dialogue_prompts.yaml
@@ -45,11 +45,11 @@ character_response: |
 evaluation_prompt: |
   請評估以下NPC回應的品質：
   
+  歷史對話：
+  {conversation_history}
   當前狀態：{current_state}
   護理人員輸入：{player_input}
   NPC回應：{response}
-
-  NPC回應中會包含五種不同的回應，請從中選擇一個回應進行評估。
   
   請從以下幾個面向進行評估，並給出0到1之間的分數。
   請只回傳 JSON 格式的評估結果，不要有其他說明文字：

--- a/src/core/dialogue.py
+++ b/src/core/dialogue.py
@@ -50,6 +50,15 @@ class DialogueManager:
             except ValueError:
                 self.current_state = DialogueState.CONFUSED
         
+        # 隨機選擇一個回答進行儲存(未來更改為病患選擇)
+        '''---------------------------------------------------------------------------------------'''
+        import random
+        random_num = random.randint(1,5)
+        random_content = [element for element in response_lines if str(random_num) in element]
+        random_content = random_content[0].split(". ")[1]
+        response_content = random_content
+        '''---------------------------------------------------------------------------------------'''
+
         # 記錄 NPC 回應
         self.conversation_history.append(f"{self.character.name}: {response_content}")
         


### PR DESCRIPTION
發現未於tester中提供歷史對話記錄：Prompt加入前5次對話記錄並於情境結束後清除
原於prompt中隨機選擇部分移出，以隨機5選1的方式選擇，方便現在儲存及未來更改為供病人選擇之程式碼