### PR TITLE
18 history 中只儲存 tester 選擇的選項

### DIFF
--- a/prompts/dialogue_prompts.yaml
+++ b/prompts/dialogue_prompts.yaml
@@ -45,11 +45,11 @@ character_response: |
 evaluation_prompt: |
   請評估以下NPC回應的品質：
   
+  歷史對話：
+  {conversation_history}
   當前狀態：{current_state}
   護理人員輸入：{player_input}
   NPC回應：{response}
-
-  NPC回應中會包含五種不同的回應，請從中選擇一個回應進行評估。
   
   請從以下幾個面向進行評估，並給出0到1之間的分數。
   請只回傳 JSON 格式的評估結果，不要有其他說明文字：

--- a/src/core/dialogue.py
+++ b/src/core/dialogue.py
@@ -50,6 +50,15 @@ class DialogueManager:
             except ValueError:
                 self.current_state = DialogueState.CONFUSED
         
+        # 隨機選擇一個回答進行儲存(未來更改為病患選擇)
+        '''---------------------------------------------------------------------------------------'''
+        import random
+        random_num = random.randint(1,5)
+        random_content = [element for element in response_lines if str(random_num) in element]
+        random_content = random_content[0].split(". ")[1]
+        response_content = random_content
+        '''---------------------------------------------------------------------------------------'''
+
         # 記錄 NPC 回應
         self.conversation_history.append(f"{self.character.name}: {response_content}")
         

--- a/src/llm/gemini_client.py
+++ b/src/llm/gemini_client.py
@@ -9,4 +9,4 @@ class GeminiClient:
 
     def generate_response(self, prompt: str) -> str:
         response = self.model.generate_content(prompt)
-        return response.text 
+        return response.text


### PR DESCRIPTION
發現未於tester 中單次情境下給予history，因此prompt 中新增歷史對話記錄部分，並給予前五次對話。於單一情境結束後清除對話紀錄。
原於prompt 中隨機選擇部分移除，將該功能改為以程式碼執行選擇：
1. 方便append 紀錄
2. 未來由病人選擇時亦較容易修改