### PR TITLE
Allow custom select_response commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ ui_debug.log
 recordings/
 third_party/
 markitdown/
+shared_context_clean_bundle.zip
 
 # Audio assets (avoid committing mp3)
 *.mp3

--- a/doc/api_documentation.md
+++ b/doc/api_documentation.md
@@ -291,40 +291,30 @@ curl -X POST http://localhost:18000/api/dialogue/audio \
 
 #### POST /api/dialogue/select_response
 
-Two-step audio flow — **step 2 of 2**. After [`/api/dialogue/audio`](#post-apidialogueaudio) returns `WAITING_SELECTION`, call this endpoint with the user's chosen transcription option.
+Selection flow — **step 2 of 2**. After `/api/dialogue/text`, `/api/dialogue/audio`, or `/api/dialogue/audio_input` returns selectable candidates, call this endpoint with the user's chosen patient response.
 
-If the selection is recognized as a post-speech-recognition choice, it is recorded without invoking the dialogue model. Otherwise, the selected text is forwarded to the dialogue model for a full dialogue turn.
+By default, `selected_response` must match one current candidate exactly after trimming leading/trailing whitespace. If the user typed their own response because none of the candidates fit, send `allow_custom=true`.
 
 **Request** (`application/json`)
 
 | Parameter | Type | Required | Description |
 |---|---|---|---|
-| `session_id` | string | Yes | Session ID from the preceding `/audio` call |
-| `selected_response` | string | Yes | The transcription option the user selected |
+| `session_id` | string | Yes | Session ID from the preceding candidate-producing call |
+| `selected_response` | string | Yes | Candidate text, or user-entered text when `allow_custom=true` |
+| `allow_custom` | boolean | No | Set to `true` only when committing user-entered text that is not one of the candidates |
 
 **Response** `200 OK`
-
-When recognized as a speech-recognition selection (most common case):
-
-```json
-{
-  "status": "success",
-  "message": "語音識別選擇已記錄",
-  "responses": ["已記錄您的選擇"],
-  "state": "NORMAL",
-  "dialogue_context": "語音識別選擇完成"
-}
-```
-
-When treated as a new dialogue turn (fallback):
 
 ```json
 {
   "status": "success",
   "message": "回應選擇已記錄",
-  "responses": ["護理師的回覆..."],
+  "responses": ["已記錄您的選擇"],
   "state": "NORMAL",
-  "dialogue_context": "一般對話"
+  "dialogue_context": "一般對話",
+  "selection_committed": true,
+  "committed_response": "我想了解手術的流程",
+  "selection_source": "candidate"
 }
 ```
 
@@ -333,6 +323,8 @@ When treated as a new dialogue turn (fallback):
 | Code | Condition |
 |---|---|
 | `404` | Session not found |
+| `409` | Current session has no pending candidate selection |
+| `400` | Empty response, or non-candidate response without `allow_custom=true` |
 | `500` | Dialogue processing error |
 
 **curl Example**
@@ -343,6 +335,18 @@ curl -X POST http://localhost:18000/api/dialogue/select_response \
   -d '{
     "session_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
     "selected_response": "我想了解手術的流程"
+  }'
+```
+
+For custom user-entered text:
+
+```bash
+curl -X POST http://localhost:18000/api/dialogue/select_response \
+  -H "Content-Type: application/json" \
+  -d '{
+    "session_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "selected_response": "我想自己輸入這一句，因為上面的選項都不適合。",
+    "allow_custom": true
   }'
 ```
 

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -148,6 +148,7 @@ class SelectResponseRequest(BaseModel):
     """選擇回應請求模型"""
     session_id: str
     selected_response: str
+    allow_custom: bool = False
 
 # 會話存儲，用於維護多個客戶端的對話狀態
 session_store: Dict[str, Dict[str, Any]] = {}
@@ -1817,8 +1818,14 @@ async def select_response(request: SelectResponseRequest):
             )
             raise HTTPException(status_code=400, detail="selected_response 不可為空")
 
+        candidate_options = pending_turn.get("candidate_options") or []
+        selection_source = "candidate" if normalized_selected in candidate_options else "custom"
+
         try:
-            committed_turn = dialogue_manager.commit_pending_turn(normalized_selected)
+            committed_turn = dialogue_manager.commit_pending_turn(
+                normalized_selected,
+                allow_custom=request.allow_custom,
+            )
         except ValueError as validation_error:
             performance_monitor.end_request(
                 context=monitoring_context,
@@ -1863,6 +1870,7 @@ async def select_response(request: SelectResponseRequest):
             "selection_committed": True,
             "selection_kind": pending_turn.get("selection_kind"),
             "committed_response": normalized_selected,
+            "selection_source": selection_source,
             "interaction_mode": "selection_committed",
             "performance_metrics": metrics_dict,
             "committed_turn": committed_turn,

--- a/src/core/dialogue.py
+++ b/src/core/dialogue.py
@@ -223,7 +223,7 @@ class DialogueManager:
     def clear_pending_turn(self) -> None:
         self.pending_turn = None
 
-    def commit_pending_turn(self, selected_response: str) -> Dict[str, Any]:
+    def commit_pending_turn(self, selected_response: str, *, allow_custom: bool = False) -> Dict[str, Any]:
         pending_turn = self.pending_turn
         if pending_turn is None:
             raise ValueError("No pending turn to commit")
@@ -233,7 +233,8 @@ class DialogueManager:
             raise ValueError("Selected response is empty")
 
         candidate_options = pending_turn.get("candidate_options") or []
-        if normalized_response not in candidate_options:
+        is_candidate = normalized_response in candidate_options
+        if not is_candidate and not allow_custom:
             raise ValueError("Selected response does not match current candidate options")
 
         committed_turn = self.append_confirmed_turn(
@@ -247,6 +248,7 @@ class DialogueManager:
             metadata={
                 "source_text": pending_turn.get("source_text", ""),
                 "selection_kind": pending_turn.get("selection_kind", ""),
+                "selection_source": "candidate" if is_candidate else "custom",
                 **(pending_turn.get("metadata") or {}),
             },
         )

--- a/src/tests/test_selection_commit_flow.py
+++ b/src/tests/test_selection_commit_flow.py
@@ -77,6 +77,7 @@ def main() -> int:
     _assert(select_result.get("selection_committed") is True, "selection was not marked committed")
     _assert(select_result.get("interaction_mode") == "selection_committed", "unexpected select interaction_mode")
     _assert(select_result.get("committed_response") == selected_response, "committed response mismatch")
+    _assert(select_result.get("selection_source") == "candidate", "selection_source should be candidate")
     _assert(select_result.get("responses") == ["已記錄您的選擇"], "select_response should only acknowledge commit")
 
     history_result = _get_json(f"/api/dev/session/{session_id}/history")

--- a/src/tests/test_selection_regression_suite.py
+++ b/src/tests/test_selection_regression_suite.py
@@ -63,10 +63,18 @@ def _get_json(path: str, expected_status: int = 200) -> requests.Response:
     return response
 
 
-def _select(session_id: str, selected_response: str, expected_status: int = 200) -> Dict[str, Any]:
+def _select(
+    session_id: str,
+    selected_response: str,
+    expected_status: int = 200,
+    allow_custom: bool = False,
+) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {"session_id": session_id, "selected_response": selected_response}
+    if allow_custom:
+        payload["allow_custom"] = True
     response = _post_json(
         "/api/dialogue/select_response",
-        {"session_id": session_id, "selected_response": selected_response},
+        payload,
         expected_status=expected_status,
     )
     return response.json()
@@ -76,11 +84,12 @@ def _history(session_id: str) -> Dict[str, Any]:
     return _get_json(f"/api/dev/session/{session_id}/history").json()
 
 
-def _assert_commit_result(result: Dict[str, Any], selected_response: str) -> None:
+def _assert_commit_result(result: Dict[str, Any], selected_response: str, selection_source: str = "candidate") -> None:
     _assert(result.get("status") == "success", "selection commit did not return success")
     _assert(result.get("selection_committed") is True, "selection_committed should be true")
     _assert(result.get("interaction_mode") == "selection_committed", "unexpected interaction_mode")
     _assert(result.get("committed_response") == selected_response, "committed response mismatch")
+    _assert(result.get("selection_source") == selection_source, "selection_source mismatch")
     _assert(result.get("responses") == ["已記錄您的選擇"], "select_response should only acknowledge commit")
 
 
@@ -220,6 +229,26 @@ def test_selection_failure_paths() -> None:
     _assert("沒有待確認的病患選項" in no_pending_result.get("detail", ""), "missing pending_turn should return 409")
 
 
+def test_custom_selection_commit_flow() -> None:
+    text_result = _post_json(
+        "/api/dialogue/text",
+        {"text": "你現在想跟護理師說什麼？", "character_id": CHARACTER_ID, "response_format": "text"},
+    ).json()
+    session_id = text_result["session_id"]
+    custom_response = "我想自己輸入這一句，因為上面的選項都不適合。"
+
+    rejected = _select(session_id, custom_response, expected_status=400)
+    _assert("does not match current candidate options" in rejected.get("detail", ""), "custom text should require allow_custom")
+
+    custom_result = _select(session_id, custom_response, allow_custom=True)
+    _assert_commit_result(custom_result, custom_response, selection_source="custom")
+
+    history_result = _history(session_id)
+    conversation_history = history_result.get("conversation_history") or []
+    _assert(conversation_history[-1].endswith(custom_response), "custom response missing from history")
+    _assert(history_result.get("pending_turn") is None, "pending_turn should be cleared after custom commit")
+
+
 def main() -> int:
     _assert(os.path.exists(AUDIO_FIXTURE), f"audio fixture not found: {AUDIO_FIXTURE}")
 
@@ -234,6 +263,9 @@ def main() -> int:
 
     test_selection_failure_paths()
     print("selection_failure_paths: PASS")
+
+    test_custom_selection_commit_flow()
+    print("custom_selection_commit_flow: PASS")
 
     print("selection_regression_suite: PASS")
     return 0


### PR DESCRIPTION
## Summary
- Add allow_custom to /api/dialogue/select_response so frontend-entered patient text can be committed intentionally.
- Preserve existing strict candidate matching by default.
- Return selection_source and document the old/new API behavior.

## Tests
- docker exec llm-quest-copilot-dev python -m py_compile /app/src/api/server.py /app/src/core/dialogue.py /app/src/tests/test_selection_commit_flow.py /app/src/tests/test_selection_regression_suite.py
- docker exec llm-quest-copilot-dev python /app/src/tests/test_selection_commit_flow.py
- docker exec llm-quest-copilot-dev python /app/src/tests/test_selection_regression_suite.py